### PR TITLE
fix: 이메일 미인증으로 인한 SELLER 상품 등록/수정 차단 임시 해제

### DIFF
--- a/product-service/src/main/java/com/notfound/product/adapter/in/web/ProductController.java
+++ b/product-service/src/main/java/com/notfound/product/adapter/in/web/ProductController.java
@@ -86,9 +86,10 @@ public class ProductController {
         if (user == null || !"SELLER".equals(user.role())) {
             throw new ForbiddenException(ProductErrorCode.FORBIDDEN.getMessage());
         }
-        if (!user.emailVerified()) {
-            throw new ForbiddenException(ProductErrorCode.EMAIL_NOT_VERIFIED.getMessage());
-        }
+        // TODO: member-service 이메일 인증 구현 후 활성화 (issue #30)
+        // if (!user.emailVerified()) {
+        //     throw new ForbiddenException(ProductErrorCode.EMAIL_NOT_VERIFIED.getMessage());
+        // }
     }
 
     private void requireAdmin(AuthenticatedUser user) {

--- a/product-service/src/test/java/com/notfound/product/adapter/in/web/ProductControllerTest.java
+++ b/product-service/src/test/java/com/notfound/product/adapter/in/web/ProductControllerTest.java
@@ -160,6 +160,22 @@ class ProductControllerTest {
         }
 
         @Test
+        @DisplayName("이메일 미인증 판매자도 201과 등록된 상품을 반환한다 (issue #30 해결 전 임시)")
+        void success_whenEmailNotVerified() throws Exception {
+            UUID productId = UUID.randomUUID();
+            given(registerProductUseCase.registerProduct(any())).willReturn(createProduct(productId));
+
+            mockMvc.perform(post("/products")
+                            .header("X-User-Id", UUID.randomUUID().toString())
+                            .header("X-Role", "SELLER")
+                            .header("X-Email-Verified", "false")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(validRequest())))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value("PRODUCT_REGISTER_SUCCESS"));
+        }
+
+        @Test
         @DisplayName("인증 헤더가 없으면 403과 FORBIDDEN을 반환한다")
         void fail_whenNoAuth() throws Exception {
             mockMvc.perform(post("/products")
@@ -180,19 +196,6 @@ class ProductControllerTest {
                             .content(objectMapper.writeValueAsString(validRequest())))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.code").value("FORBIDDEN"));
-        }
-
-        @Test
-        @DisplayName("이메일 미인증 판매자면 403과 EMAIL_NOT_VERIFIED를 반환한다")
-        void fail_whenEmailNotVerified() throws Exception {
-            mockMvc.perform(post("/products")
-                            .header("X-User-Id", UUID.randomUUID().toString())
-                            .header("X-Role", "SELLER")
-                            .header("X-Email-Verified", "false")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(validRequest())))
-                    .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.code").value("EMAIL_NOT_VERIFIED"));
         }
 
         @Test


### PR DESCRIPTION
## Summary
- `ProductController.requireSeller()`의 `emailVerified` 체크를 주석 처리
- member-service 이메일 인증 기능 미구현으로 모든 유저가 `emailVerified = false` 상태 → SELLER의 상품 등록/수정이 전면 차단되던 문제 해결
- `EMAIL_NOT_VERIFIED` 에러코드는 유지, issue #30 해결 시 즉시 재활성화 예정

## Test plan
- [ ] SELLER + `X-Email-Verified: false` → `POST /products` 201 반환 확인
- [ ] SELLER + `X-Email-Verified: false` → `PATCH /products/{id}` 200 반환 확인
- [ ] 비판매자(USER) → `POST /products` 여전히 403 반환 확인
- [ ] `./gradlew :product-service:test` 전체 통과 확인

## 관련 이슈
ref #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 상품 등록 시 이메일 인증 필수 조건을 제거했습니다. 판매자 역할이 있는 사용자는 이제 이메일 인증 여부에 상관없이 상품을 정상 등록할 수 있습니다. 기존에는 인증되지 않은 이메일로 인해 등록이 차단되었으나, 이제는 판매자 권한 확인만 수행합니다. 이를 통해 사용자 경험이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->