### PR TITLE
fix: Swagger Server URL을 OpenAPI Bean으로 설정

### DIFF
--- a/member-service/src/main/java/com/notfound/member/infrastructure/config/OpenApiConfig.java
+++ b/member-service/src/main/java/com/notfound/member/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.notfound.member.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${gateway.url:http://localhost:8080}")
+    private String gatewayUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url(gatewayUrl + "/api/member"));
+    }
+}

--- a/member-service/src/main/resources/application.yml
+++ b/member-service/src/main/resources/application.yml
@@ -34,8 +34,10 @@ admin:
 internal:
   secret: ${INTERNAL_SECRET_KEY}
 
+gateway:
+  url: ${GATEWAY_URL:http://localhost:8080}
+
 springdoc:
-  override-server-url: ${GATEWAY_URL:http://localhost:8080}/api/member
   swagger-ui:
     path: /swagger-ui/index.html
     config-url: /member/v3/api-docs/swagger-config

--- a/order-service/src/main/java/com/notfound/order/infrastructure/config/OpenApiConfig.java
+++ b/order-service/src/main/java/com/notfound/order/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.notfound.order.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${gateway.url:http://localhost:8080}")
+    private String gatewayUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url(gatewayUrl + "/api/order"));
+    }
+}

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -38,8 +38,10 @@ order:
 internal:
   secret-key: ${INTERNAL_SECRET_KEY}
 
+gateway:
+  url: ${GATEWAY_URL:http://localhost:8080}
+
 springdoc:
-  override-server-url: ${GATEWAY_URL:http://localhost:8080}/api/order
   swagger-ui:
     path: /swagger-ui/index.html
     config-url: /order/v3/api-docs/swagger-config

--- a/payment-service/src/main/java/com/notfound/payment/infrastructure/config/OpenApiConfig.java
+++ b/payment-service/src/main/java/com/notfound/payment/infrastructure/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.notfound.payment.infrastructure.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${gateway.url:http://localhost:8080}")
+    private String gatewayUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url(gatewayUrl + "/api/payment"));
+    }
+}

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -25,8 +25,10 @@ eureka:
 internal:
   secret-key: ${INTERNAL_SECRET_KEY}
 
+gateway:
+  url: ${GATEWAY_URL:http://localhost:8080}
+
 springdoc:
-  override-server-url: ${GATEWAY_URL:http://localhost:8080}/api/payment
   swagger-ui:
     path: /swagger-ui/index.html
     config-url: /payment/v3/api-docs/swagger-config

--- a/product-service/src/main/java/com/notfound/product/adapter/in/web/config/OpenApiConfig.java
+++ b/product-service/src/main/java/com/notfound/product/adapter/in/web/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.notfound.product.adapter.in.web.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${gateway.url:http://localhost:8080}")
+    private String gatewayUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url(gatewayUrl + "/api/product"));
+    }
+}

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -25,8 +25,10 @@ eureka:
 internal:
   secret: ${INTERNAL_SECRET_KEY}
 
+gateway:
+  url: ${GATEWAY_URL:http://localhost:8080}
+
 springdoc:
-  override-server-url: ${GATEWAY_URL:http://localhost:8080}/api/product
   swagger-ui:
     path: /swagger-ui/index.html
     config-url: /product/v3/api-docs/swagger-config

--- a/settlement-service/src/main/java/com/notfound/settlement/config/OpenApiConfig.java
+++ b/settlement-service/src/main/java/com/notfound/settlement/config/OpenApiConfig.java
@@ -1,0 +1,20 @@
+package com.notfound.settlement.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Value("${gateway.url:http://localhost:8080}")
+    private String gatewayUrl;
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url(gatewayUrl + "/api/settlement"));
+    }
+}

--- a/settlement-service/src/main/resources/application.yml
+++ b/settlement-service/src/main/resources/application.yml
@@ -43,8 +43,10 @@ settlement:
 internal:
   secret-key: ${INTERNAL_SECRET_KEY}
 
+gateway:
+  url: ${GATEWAY_URL:http://localhost:8080}
+
 springdoc:
-  override-server-url: ${GATEWAY_URL:http://localhost:8080}/api/settlement
   swagger-ui:
     path: /swagger-ui/index.html
     config-url: /settlement/v3/api-docs/swagger-config


### PR DESCRIPTION
## Summary
- `springdoc.override-server-url`이 Spring Boot 4.x에서 동작하지 않는 문제 수정
- 각 서비스에 `OpenApiConfig` Bean 추가하여 서버 URL 직접 설정
- 로컬: `GATEWAY_URL` 미설정 시 `http://localhost:8080` 기본값 사용
- EC2: `GATEWAY_URL=http://43.200.75.98` 주입

## Test plan
- [ ] 로컬 product-service 실행 후 `/v3/api-docs` servers 항목 확인
- [ ] CD 배포 후 Swagger UI Server URL 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * API 게이트웨이 URL 설정이 모든 마이크로서비스에서 일관되게 구성됩니다.
  * API 문서화 서버 구성이 환경 설정을 통해 더욱 효율적으로 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->