### PR TITLE
fix: Swagger Server URL OpenAPI Bean 설정 및 CD 타임아웃 증가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,7 +95,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          command_timeout: 10m
+          command_timeout: 20m
           script: |
             cat > /home/ec2-user/app/.env << 'ENVEOF'
             DB_USERNAME=${{ secrets.DB_USERNAME }}


### PR DESCRIPTION
## Summary
- `springdoc.override-server-url`이 Spring Boot 4.x에서 동작하지 않아 각 서비스에 `OpenApiConfig` Bean으로 대체
- CD SSH command timeout 10m → 20m 증가 (7개 서비스 전체 pull 시 타임아웃 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

이 변경 사항은 내부 배포 인프라 조정에만 해당하며, 사용자에게 보이는 기능이나 동작에는 영향을 주지 않습니다.

* **Chores**
  * 배포 프로세스 타임아웃 설정 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->