### PR TITLE
feat: Swagger UI BearerAuth 인증 버튼 추가

### DIFF
--- a/member-service/src/main/java/com/notfound/member/infrastructure/config/OpenApiConfig.java
+++ b/member-service/src/main/java/com/notfound/member/infrastructure/config/OpenApiConfig.java
@@ -1,6 +1,9 @@
 package com.notfound.member.infrastructure.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +18,12 @@ public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .addServersItem(new Server().url(gatewayUrl + "/api/member"));
+                .addServersItem(new Server().url(gatewayUrl + "/api/member"))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/order-service/src/main/java/com/notfound/order/infrastructure/config/OpenApiConfig.java
+++ b/order-service/src/main/java/com/notfound/order/infrastructure/config/OpenApiConfig.java
@@ -1,6 +1,9 @@
 package com.notfound.order.infrastructure.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +18,12 @@ public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .addServersItem(new Server().url(gatewayUrl + "/api/order"));
+                .addServersItem(new Server().url(gatewayUrl + "/api/order"))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/payment-service/src/main/java/com/notfound/payment/infrastructure/config/OpenApiConfig.java
+++ b/payment-service/src/main/java/com/notfound/payment/infrastructure/config/OpenApiConfig.java
@@ -1,6 +1,9 @@
 package com.notfound.payment.infrastructure.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +18,12 @@ public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .addServersItem(new Server().url(gatewayUrl + "/api/payment"));
+                .addServersItem(new Server().url(gatewayUrl + "/api/payment"))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/product-service/src/main/java/com/notfound/product/adapter/in/web/config/OpenApiConfig.java
+++ b/product-service/src/main/java/com/notfound/product/adapter/in/web/config/OpenApiConfig.java
@@ -1,6 +1,9 @@
 package com.notfound.product.adapter.in.web.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +18,12 @@ public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .addServersItem(new Server().url(gatewayUrl + "/api/product"));
+                .addServersItem(new Server().url(gatewayUrl + "/api/product"))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }

--- a/settlement-service/src/main/java/com/notfound/settlement/config/OpenApiConfig.java
+++ b/settlement-service/src/main/java/com/notfound/settlement/config/OpenApiConfig.java
@@ -1,6 +1,9 @@
 package com.notfound.settlement.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +18,12 @@ public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .addServersItem(new Server().url(gatewayUrl + "/api/settlement"));
+                .addServersItem(new Server().url(gatewayUrl + "/api/settlement"))
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
     }
 }


### PR DESCRIPTION
## Summary
- 모든 서비스(member, product, order, payment, settlement)의 `OpenApiConfig`에 `SecurityScheme(BearerAuth)` 추가
- Swagger UI 상단에 **Authorize** 버튼 노출, JWT 토큰 입력 후 인증된 API 테스트 가능

## Test plan
- [ ] Swagger UI 접속 후 Authorize 버튼 노출 확인
- [ ] 로그인 후 발급된 토큰 입력
- [ ] 인증 필요 API (POST /api/product/products 등) 정상 호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * API 문서에 JWT 기반 Bearer 인증 스키마가 추가되었습니다. 모든 마이크로서비스의 OpenAPI 명세에 인증 요구사항이 명시되어, 클라이언트가 API 사용 시 필요한 인증 방식을 더욱 명확하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->